### PR TITLE
Support number for issue instead of id

### DIFF
--- a/src/components/project.jsx
+++ b/src/components/project.jsx
@@ -34,7 +34,7 @@ export default class Project extends React.Component{
         if(open_issues_count === 0){
             return "No open issue.";
         }
-        return openIssues.map((issue) => (<div> <a href={issue.html_url}> # {issue.id || ''}: {issue.title} </a></div>))
+        return openIssues.map((issue) => (<div> <a href={issue.html_url}> # {issue.id || issue.number || ''}: {issue.title} </a></div>))
 
     })();
 


### PR DESCRIPTION
Since Github API uses number to reference the issue in the repo instead of id (that is a unique id over all repos on github ever), frontend should support attribute number. See https://developer.github.com/v3/issues/ for details on differences between id and number on Github.